### PR TITLE
Fix: box gets repositioned on props change

### DIFF
--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -189,7 +189,7 @@ function BoxImpl(
   const group = useRef<THREE.Group>()
   const node = useMemo(() => Yoga.Node.create(), [])
   const reflow = useReflow()
-  const position = useRef(parent?.getChildCount());
+  const position = useRef(parent?.getChildCount())
 
   useLayoutEffect(() => {
     setYogaProperties(node, flexProps, scaleFactor)
@@ -200,7 +200,7 @@ function BoxImpl(
     if (!group.current || !parent) return
 
     position.current = position.current || parent.getChildCount()
-    parent.insertChild(node, position.current);
+    parent.insertChild(node, position.current)
 
     registerBox(node, group.current, flexProps, centerAnchor)
 

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -189,6 +189,7 @@ function BoxImpl(
   const group = useRef<THREE.Group>()
   const node = useMemo(() => Yoga.Node.create(), [])
   const reflow = useReflow()
+  const position = useRef(parent?.getChildCount());
 
   useLayoutEffect(() => {
     setYogaProperties(node, flexProps, scaleFactor)
@@ -198,7 +199,9 @@ function BoxImpl(
   useLayoutEffect(() => {
     if (!group.current || !parent) return
 
-    parent.insertChild(node, parent.getChildCount())
+    position.current = position.current || parent.getChildCount()
+    parent.insertChild(node, position.current);
+
     registerBox(node, group.current, flexProps, centerAnchor)
 
     // Remove child on unmount


### PR DESCRIPTION
Hi there!

I noticed that if I update the width of an element, it gets moved to the end of its parent:
![flex-width-bug](https://user-images.githubusercontent.com/9637975/198896402-21937d1d-5696-4b8a-8468-b21179bcc8e5.gif)

The issue seems to be that we're always inserting elements at the end, even when we're just updating the flexProps. Behavior with this change:
![flex-bug-fix](https://user-images.githubusercontent.com/9637975/198896565-9d77b165-becd-41c7-9f2d-1220cbeef477.gif)

I'm not familiar with Yoga at all so I'm happy to close this in favor of a better fix if you have one!

Thanks!